### PR TITLE
Add AsError method to Panic

### DIFF
--- a/cmd/test/test.go
+++ b/cmd/test/test.go
@@ -73,13 +73,13 @@ func executeCommand(cmd string) {
 		projectDir := path.Dir(path.Dir(path.Dir(filename)))
 
 		stderr("main.executeCommand(0x7fff79030f93, 0x22)")
-		stderr(fmt.Sprintf("\t\t%s/cmd/test/test.go:83 +0x8d7", projectDir))
+		stderr(fmt.Sprintf("\t%s/cmd/test/test.go:83 +0x8d7", projectDir))
 
 		_ = os.Stderr.Sync()
 
 		stderr("main.main()")
 
-		stderr(fmt.Sprintf("\t\t%s/cmd/test/test.go:42 +0x12ab", projectDir))
+		stderr(fmt.Sprintf("\t%s/cmd/test/test.go:42 +0x12ab", projectDir))
 		os.Exit(2)
 	case "panic-with-garbage":
 		stderr("panic: blah blah\n")

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/glycerine/goconvey v0.0.0-20190410193231-58a59202ab31 // indirect
 	github.com/glycerine/rbuf v0.0.0-20190314090850-75b78581bebe
+	github.com/go-errors/errors v1.4.0
 	github.com/gopherjs/gopherjs v0.0.0-20210519211817-2312de329ae4 // indirect
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/sys v0.0.0-20210521090106-6ca3eb03dfc2

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/glycerine/goconvey v0.0.0-20190410193231-58a59202ab31 h1:gclg6gY70GLy
 github.com/glycerine/goconvey v0.0.0-20190410193231-58a59202ab31/go.mod h1:Ogl1Tioa0aV7gstGFO7KhffUsb9M4ydbEbbxpcEDc24=
 github.com/glycerine/rbuf v0.0.0-20190314090850-75b78581bebe h1:S7HF/JKUdDrsd66htKdBOt/t3WvhU3l8EXe0U3WxEDA=
 github.com/glycerine/rbuf v0.0.0-20190314090850-75b78581bebe/go.mod h1:BOGkN1CszB3i4g9xn96RH4t5uXnxJjnC5/RWJ1Wx7GM=
+github.com/go-errors/errors v1.4.0 h1:2OA7MFw38+e9na72T1xgkomPb6GzZzzxvJ5U630FoRM=
+github.com/go-errors/errors v1.4.0/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=

--- a/panicwatch.go
+++ b/panicwatch.go
@@ -11,11 +11,21 @@ import (
 	"regexp"
 
 	"github.com/glycerine/rbuf"
+	goerrors "github.com/go-errors/errors"
 )
 
 type Panic struct {
 	Message string
 	Stack   string
+}
+
+func (p Panic) AsError() error {
+	parsedErr, err := goerrors.ParsePanic("panic: " + p.Message + "\n" + p.Stack)
+	if err != nil {
+		return errors.New(p.Message)
+	}
+
+	return parsedErr
 }
 
 type Config struct {


### PR DESCRIPTION
Error returned by this method will contain parsed stacktrace.
This is useful for error reporting tools, eg. Sentry