### PR TITLE
Make the duplicate stderr be Close-on-Exec

### DIFF
--- a/dup.go
+++ b/dup.go
@@ -10,7 +10,7 @@ import (
 )
 
 func dup(oldfd int) (fd int, err error) {
-	return unix.FcntlInt(oldfd, unix.F_DUPFD_CLOEXEC, 0)
+	return unix.FcntlInt(uintptr(oldfd), unix.F_DUPFD_CLOEXEC, 0)
 }
 
 func redirectStderr(target *os.File) error {

--- a/dup.go
+++ b/dup.go
@@ -10,7 +10,7 @@ import (
 )
 
 func dup(oldfd int) (fd int, err error) {
-	return unix.Dup(oldfd)
+	return unix.FcntlInt(oldfd, unix.F_DUPFD_CLOEXEC, 0)
 }
 
 func redirectStderr(target *os.File) error {


### PR DESCRIPTION
This change makes it such that the child process does not have any leaked file descriptors.