### PR TITLE
Adding support for fatal errors

### DIFF
--- a/cmd/test/test.go
+++ b/cmd/test/test.go
@@ -97,11 +97,12 @@ func executeCommand(cmd string) {
 	case "fatal":
 		// force a concurrent map error
 		m := make(map[int]int)
-		go func() {
+		go func() { //nolint:wsl
 			for {
 				m[0] = 0
 			}
 		}()
+
 		for {
 			m[0] = 0
 		}

--- a/cmd/test/test.go
+++ b/cmd/test/test.go
@@ -94,6 +94,17 @@ func executeCommand(cmd string) {
 		stderr("panic: this is fake\n")
 
 		panic("and this is not")
+	case "fatal":
+		// force a concurrent map error
+		m := make(map[int]int)
+		go func() {
+			for {
+				m[0] = 0
+			}
+		}()
+		for {
+			m[0] = 0
+		}
 	default:
 		stderr("unknown command:", cmd)
 		os.Exit(3)

--- a/panicwatch.go
+++ b/panicwatch.go
@@ -153,6 +153,7 @@ func checkConfig(config *Config) error {
 	return nil
 }
 
+//nolint:gochecknoglobals
 var panicTypes = []string{
 	string(TypePanic),
 	string(TypeFatalError),
@@ -220,7 +221,8 @@ func findLastPanicStartIndex(b []byte) int {
 }
 
 func parsePanic(raw []byte) *Panic {
-	panicRegex := regexp.MustCompile(`(?sm)(` + strings.Join(panicTypes, "|") + ")" + panicHeaderSuffix + `(.*?$)?\n+(.*)\z`)
+	panicRegex := regexp.MustCompile(`(?sm)(` + strings.Join(panicTypes, "|") + ")" +
+		panicHeaderSuffix + `(.*?$)?\n+(.*)\z`)
 
 	matches := panicRegex.FindSubmatch(raw)
 	if matches != nil {

--- a/panicwatch_test.go
+++ b/panicwatch_test.go
@@ -151,7 +151,8 @@ func TestPanicwatch(t *testing.T) {
 			assert.Equal(expectedPanicType, result.Type)
 
 			expectedPanicStart := fmt.Sprintf("%s: %s\n\n", expectedPanicType, test.expectedPanic)
-			assert.True(strings.HasPrefix(actualStderr, expectedPanicStart))
+			assert.True(strings.HasPrefix(actualStderr, expectedPanicStart),
+				"%q does not start with %q", actualStderr, expectedPanicStart)
 			actualStderr = strings.TrimPrefix(actualStderr, test.expectedStderr)
 
 			assert.Regexp(panicRegex, actualStderr)


### PR DESCRIPTION
Go programs can crash for other reasons than panics; most notably, they can crash due to a variety of `fatal error`s.

This patch makes panicwatch able to recognize these.

Added/updated tests.