### PR TITLE
Add support for fatal errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,7 +15,6 @@ linters: # 2022-07-21 modified
         - exhaustive
         - exportloopref
         - gci
-        - gochecknoglobals
         - gochecknoinits
         - gocognit # probably tune
         - goconst

--- a/cmd/test/test.go
+++ b/cmd/test/test.go
@@ -41,7 +41,7 @@ func main() {
 	executeCommand(args[0])
 }
 
-func executeCommand(cmd string) {
+func executeCommand(cmd string) { //nolint:cyclop // we must keep everything here because of stack traces
 	switch cmd {
 	case "no-panic":
 		stdout("some stdout output")
@@ -93,6 +93,18 @@ func executeCommand(cmd string) {
 		stderr("panic: this is fake\n")
 
 		panic("and this is not")
+	case "fatal-error": // force a concurrent map error
+		m := make(map[int]int)
+
+		go func() {
+			for {
+				m[0] = 0
+			}
+		}()
+
+		for {
+			m[0] = 0
+		}
 	default:
 		stderr("unknown command:", cmd)
 		os.Exit(3)


### PR DESCRIPTION
Go programs can crash for other reasons than panics; most notably, they can crash due to a variety of fatal errors.

Based on work in https://github.com/grongor/panicwatch/pull/11