### PR TITLE
Make the duplicate stderr be Close-on-Exec

### DIFF
--- a/dup.go
+++ b/dup.go
@@ -9,7 +9,7 @@ import (
 )
 
 func dup(oldfd int) (fd int, err error) {
-	return unix.Dup(oldfd)
+	return unix.FcntlInt(uintptr(oldfd), unix.F_DUPFD_CLOEXEC, 0)
 }
 
 func redirectStderr(target *os.File) error {

--- a/dup_linux.go
+++ b/dup_linux.go
@@ -9,7 +9,7 @@ import (
 )
 
 func dup(oldfd int) (fd int, err error) {
-	return unix.Dup(oldfd)
+	return unix.FcntlInt(uintptr(oldfd), unix.F_DUPFD_CLOEXEC, 0)
 }
 
 func redirectStderr(target *os.File) error {

--- a/dup_windows.go
+++ b/dup_windows.go
@@ -1,8 +1,9 @@
 package panicwatch
 
 import (
-	"golang.org/x/sys/windows"
 	"os"
+
+	"golang.org/x/sys/windows"
 )
 
 func dup(oldfd int) (int, error) {
@@ -11,13 +12,13 @@ func dup(oldfd int) (int, error) {
 	var fdHandle windows.Handle
 
 	err := windows.DuplicateHandle(
-		processHandle,
-		windows.Handle(oldfd),
-		processHandle,
-		&fdHandle,
-		0,
-		true,
-		windows.DUPLICATE_SAME_ACCESS,
+		processHandle,                 // hSourceProcessHandle
+		windows.Handle(oldfd),         // hSourceHandle
+		processHandle,                 // hTargetProcessHandle
+		&fdHandle,                     // lpTargetHandle
+		0,                             // dwDesiredAccess
+		false,                         // bInheritHandle
+		windows.DUPLICATE_SAME_ACCESS, // dwOptions
 	)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
This change makes it such that the child process does not have any leaked file descriptors.

Based on work in https://github.com/grongor/panicwatch/pull/8