### PR TITLE
Increase default PanicDetectorBufferSize

### DIFF
--- a/panicwatch.go
+++ b/panicwatch.go
@@ -148,7 +148,7 @@ func checkConfig(config *Config) error {
 	}
 
 	if config.PanicDetectorBufferSize == 0 {
-		config.PanicDetectorBufferSize = 1e5
+		config.PanicDetectorBufferSize = 2 * 1e7
 	}
 
 	return nil


### PR DESCRIPTION
The old value of 0.1 MB was quite conservative and would cause detection failures even for a few hundred goroutines. The new value of 20 MB should suffice for most applications while not consuming "too much RAM".